### PR TITLE
Upgrade Jackson from 2.9.10 to 2.16.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ subprojects {
   }
 
   ext {
-    jacksonVersion = '2.15.4'
+    jacksonVersion = '2.16.2'
     jacksonDatabindVersion = "$jacksonVersion"
     powermockVersion = '1.6.6'
   }

--- a/build.gradle
+++ b/build.gradle
@@ -9,8 +9,8 @@ subprojects {
   }
 
   ext {
-    jacksonVersion = '2.9.10'
-    jacksonDatabindVersion = "$jacksonVersion.8"
+    jacksonVersion = '2.15.4'
+    jacksonDatabindVersion = "$jacksonVersion"
     powermockVersion = '1.6.6'
   }
 

--- a/intercom-java/src/main/java/io/intercom/api/MapperSupport.java
+++ b/intercom-java/src/main/java/io/intercom/api/MapperSupport.java
@@ -20,6 +20,7 @@ public class MapperSupport {
                     .configure(SerializationFeature.INDENT_OUTPUT, true)
                     .configure(SerializationFeature.WRITE_DATE_TIMESTAMPS_AS_NANOSECONDS, false)
                     .configure(DeserializationFeature.READ_DATE_TIMESTAMPS_AS_NANOSECONDS, false)
+                    .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
                     .registerModule(customAttributeModule());
         }
 

--- a/intercom-java/src/main/java/io/intercom/api/MapperSupport.java
+++ b/intercom-java/src/main/java/io/intercom/api/MapperSupport.java
@@ -19,6 +19,7 @@ public class MapperSupport {
             return om.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, true)
                     .configure(SerializationFeature.INDENT_OUTPUT, true)
                     .configure(SerializationFeature.WRITE_DATE_TIMESTAMPS_AS_NANOSECONDS, false)
+                    .configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false)
                     .configure(DeserializationFeature.READ_DATE_TIMESTAMPS_AS_NANOSECONDS, false)
                     .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
                     .registerModule(customAttributeModule());


### PR DESCRIPTION
#### Why?

Issue:
- https://github.com/intercom/intercom-java/issues/311

As described in the linked issue, if another dependency has Jackson as a transitive dependency and causes it to be updated to >2.15 in a project, then the Intercom `HttpClient.readEntity` method breaks (it begins to throw Jackson Databind `UnrecognizedPropertyException`s at runtime).

This PR attempts to upgrade the Jackson dependency of intercom-java & then fix the `ObjectMapper` as necessary.

See also:
- https://github.com/intercom/intercom-java/pull/289

#### How?

1. Update Jackson from 2.9 to 2.15
    - Run tests, confirm they still pass.
2. Then update Jackson to 2.16
    - Run tests, confirm that they now begin to fail with: `com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException: Unrecognized field "type" (class io.intercom.api.TypedData), not marked as ignorable (0 known properties: ])`
3. Fix usage of Jackson `ObjectMapper`: 


- Try to add the necessary `ObjectMapper` configurations to `MapperSupport`so that it will (once again, as in older versions of Jackson) ignore any uncrecognized properties.
    - Set `FAIL_ON_UNKNOWN_PROPERTIES` to false
    - => This makes some of the tests pass; however, other tests still fail with `com.fasterxml.jackson.databind.exc.InvalidDefinitionException: No serializer found for class io.intercom.api.TypedData and no properties discovered to create BeanSerializer (to avoid exception, disable SerializationFeature.FAIL_ON_EMPTY_BEANS) (through reference chain: io.intercom.api.User["companies"]`
    - => Set `FAIL_ON_EMPTY_BEANS` to false
    - However, other tests till fail with e.g. `java.lang.ClassCastException: io.intercom.api.TypedData cannot be cast to io.intercom.api.Segment`. 

It seems that something breaks the serialization of nested fields that are collections, such as `tags` and `segments`:
```
  "segments" : {
    "segments" : [ { } ],
    "type" : "segment.list"
  },
  "tags" : {
    "tags" : [ { } ],
    "type" : "tag.list"
  }
```
should be:
```
  "segments": {
    "type": "segment.list",
    "segments": [
      {
        "id": "5310d8e7598c9a0b24000002"
      }
    ]
  },
  "tags": {
    "type": "tag.list",
    "tags": [
      {
        "id": "202"
      }
    ]
  }
```